### PR TITLE
Alias hashPW to hashPassword

### DIFF
--- a/models/BCrypt.cfc
+++ b/models/BCrypt.cfc
@@ -30,6 +30,14 @@ component singleton threadsafe{
 		var salt = variables.BCrypt.genSalt( javaCast( "int", arguments.workFactor ) );
 		return variables.BCrypt.hashpw( password, salt );
 	}
+
+	public string function hashPW( required string password, workFactor=variables.settings.workFactor) {
+		return hashPassword(argumentCollection=arguments);
+	}
+
+	public string function genSalt(numeric workFactor = variables.settings.workFactor) {
+		return variables.BCrypt.genSalt(javaCast("int",arguments.workFactor));
+	}
 	
 	/**
 	* Check a password
@@ -39,6 +47,11 @@ component singleton threadsafe{
 	public boolean function checkPassword( required string candidate, required string bCryptHash ){
 		return variables.BCrypt.checkpw( candidate, bCryptHash );
 	}
+
+	public boolean function checkPW( required string candidate, required string bCryptHash ){
+		return checkPassword(argumentCollection=arguments);
+	}
+
 	
 	/**
 	* Load the library


### PR DESCRIPTION
This is a small thing, but in the course of converting a couple of projects from direct instantiation of the BCrypt class to using the BCrypt module, we found that we had to change the function names in our services and didn't especially want to do that.

I've added three functions:

hashPW --> returns hashPassword()
checkPW --> returns checkPassword()
genSalt --> calls genSalt from the class file

This allows for a seamless "drop-in" transition to the BCrypt module. We've done this locally and it works well for us. I can see a case for disambiguation, but since BCrypt.cfc is really acting as a passthru for the underlying class, the convenience of being able to just plug it in wins out for us unless there's some other reason I'm not aware of to keep the function names between the class and the component distinct.